### PR TITLE
Enhance Docker and Compose for DinD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ docker run -p 8080:8080 \
   -v ./config.json:/app/config.json:ro \
   -e MCP_PROXY_CONFIG=/app/config.json \
   --privileged \
+  --user "$(id -u):$(id -g)" \
   ghcr.io/timthesinner/smart-mcp-proxy:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ docker pull ghcr.io/timthesinner/smart-mcp-proxy:latest
 Run the Docker container with:
 
 ```bash
-docker run -p 8080:8080 ghcr.io/timthesinner/smart-mcp-proxy:latest
+docker run -p 8080:8080 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v ./config.json:/app/config.json:ro \
+  -e MCP_PROXY_CONFIG=/app/config.json \
+  --privileged \
+  ghcr.io/timthesinner/smart-mcp-proxy:latest
 ```
 
 This will start the Smart MCP Proxy server, listening on port 8080.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,5 +8,7 @@ services:
       - "9090:8080"
     volumes:
       - ./config.json:/app/config.json:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - MCP_PROXY_CONFIG=/app/config.json
+    privileged: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,5 +10,7 @@ services:
       - ./config.json:/app/config.json:ro
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - GIN_MODE=debug
       - MCP_PROXY_CONFIG=/app/config.json
+    user: "${UID}:${GID}"
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - MCP_PROXY_CONFIG=/app/config.json
+    user: "${UID}:${GID}"
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
       - "8080:8080"
     volumes:
       - ./config.json:/app/config.json:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - MCP_PROXY_CONFIG=/app/config.json
+    privileged: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+
 # Create a non-root user to run the Go process
-RUN useradd -m -d /home/proxyuser -s /bin/bash proxyuser
+RUN groupadd -f docker && useradd -m -d /home/proxyuser -s /bin/bash proxyuser && usermod -aG docker proxyuser
 
 # Copy the Go binary from builder stage
 COPY --from=builder /smart-mcp-proxy /usr/local/bin/smart-mcp-proxy
@@ -62,6 +63,9 @@ USER proxyuser
 
 # Expose port 8080
 EXPOSE 8080
+
+# Set the web server in release mode
+ENV GIN_MODE=release
 
 # Default command to run the Go binary
 CMD ["/usr/local/bin/smart-mcp-proxy"]

--- a/docs/docker-compose-dind-example.yml
+++ b/docs/docker-compose-dind-example.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+  dind:
+    image: docker:dind
+    privileged: true
+    environment:
+      - DOCKER_TLS_CERTDIR=""
+    volumes:
+      - dind-storage:/var/lib/docker
+
+  smart-mcp-proxy:
+    container_name: smart-mcp-proxy
+    image: ghcr.io/timthesinner/smart-mcp-proxy:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.json:/app/config.json:ro
+    environment:
+      - MCP_PROXY_CONFIG=/app/config.json
+      - DOCKER_HOST=tcp://dind:2375
+    privileged: true
+    depends_on:
+      - dind
+
+volumes:
+  dind-storage:

--- a/docs/docker-compose-dind-example.yml
+++ b/docs/docker-compose-dind-example.yml
@@ -1,21 +1,20 @@
-version: "3.8"
-
 services:
   dind:
     image: docker:dind
     privileged: true
+    user: "${UID}:${GID}"
     environment:
       - DOCKER_TLS_CERTDIR=""
     volumes:
       - dind-storage:/var/lib/docker
 
   smart-mcp-proxy:
-    container_name: smart-mcp-proxy
+    container_name: smart-mcp-proxy-dind
     image: ghcr.io/timthesinner/smart-mcp-proxy:latest
     ports:
       - "8080:8080"
     volumes:
-      - ./config.json:/app/config.json:ro
+      - ../config.json:/app/config.json:ro
     environment:
       - MCP_PROXY_CONFIG=/app/config.json
       - DOCKER_HOST=tcp://dind:2375

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,8 +38,31 @@ export MCP_PROXY_CONFIG=/path/to/config.json
 
 See the example configuration file at `configs/example-config.json` for a sample setup, including examples of both HTTP-based and stdio-based MCP server configurations.
 
+## Docker-in-Docker (DinD) Support and Security Considerations
 
-## Using Docker-in-Docker (DinD) Sidecar for CI or Isolation
+The smart-mcp-proxy project supports Docker-in-Docker (DinD) usage in two primary ways: by mounting the host Docker socket directly or by using a DinD sidecar container. Each approach has distinct security implications and usage scenarios.
+
+### Mounting the Host Docker Socket
+
+You can enable DinD support by mounting the host's Docker socket (`/var/run/docker.sock`) into the `smart-mcp-proxy` container. This allows the proxy server to communicate directly with the host Docker daemon.
+
+**Security Implications:**
+
+- Mounting the Docker socket grants the container full control over the host's Docker daemon.
+- This effectively provides root-level access to the host system via Docker.
+- Use this method only in trusted environments where you control the container and host security.
+- Avoid using this approach in untrusted or multi-tenant environments.
+
+**Enabling Socket Mounting:**
+
+- In `docker-compose.yml` and `docker-compose-dev.yml`, mount the Docker socket as a volume:
+  ```yaml
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+  ```
+- Optionally, run the container in privileged mode to enable additional capabilities if required.
+
+### Using the DinD Sidecar Approach
 
 For CI/CD pipelines or scenarios where mounting the host Docker socket is not possible or desirable, you can run the MCP Proxy Server alongside a Docker-in-Docker (DinD) sidecar service.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,33 @@ export MCP_PROXY_CONFIG=/path/to/config.json
 
 See the example configuration file at `configs/example-config.json` for a sample setup, including examples of both HTTP-based and stdio-based MCP server configurations.
 
+
+## Using Docker-in-Docker (DinD) Sidecar for CI or Isolation
+
+For CI/CD pipelines or scenarios where mounting the host Docker socket is not possible or desirable, you can run the MCP Proxy Server alongside a Docker-in-Docker (DinD) sidecar service.
+
+This approach provides full Docker daemon isolation by running a separate Docker daemon inside a privileged container. The MCP Proxy Server is configured to communicate with this DinD daemon over TCP.
+
+### Example Setup
+
+An example Docker Compose file `docker-compose-dind-example.yml` is provided in the project root. It includes:
+
+- A `dind` service using the `docker:dind` image, running in privileged mode with TLS disabled.
+- The `smart-mcp-proxy` service configured with the environment variable `DOCKER_HOST=tcp://dind:2375` to connect to the DinD daemon.
+- A named volume `dind-storage` for Docker daemon storage.
+
+### When to Use
+
+- In CI/CD pipelines where the host Docker socket cannot be mounted.
+- When full isolation of the Docker daemon is required.
+- For advanced scenarios requiring a separate Docker daemon lifecycle.
+
+To use this setup, run:
+
+```bash
+docker-compose -f docker-compose-dind-example.yml up
+```
+
 ## Using stdio-based MCP Servers
 
 For MCP servers configured with the `command` field (stdio-based), the proxy server will start the specified command as a local process. You can optionally specify command-line arguments using the `args` field and environment variables using the `env` field in the configuration.


### PR DESCRIPTION
This PR implements issue #6 by enhancing docker-compose.yml and docker-compose-dev.yml for Docker-in-Docker (DinD) support, adding a DinD sidecar example, updating documentation with security and usage instructions, and updating the README docker run command.